### PR TITLE
Add TABLE_OBJS variable for arch avr8

### DIFF
--- a/configure
+++ b/configure
@@ -262,6 +262,7 @@ for option in $@; do
     ASM_OBJS="${ASM_OBJS} avr8.o"
     DISASM_OBJS="${DISASM_OBJS} avr8.o"
     SIM_OBJS="${SIM_OBJS} avr8.o"
+    TABLE_OBJS="${TABLE_OBJS} avr8.o"
     DFLAGS="${DFLAGS} -DENABLE_AVR8"
   ;;
   --enable-dspic)


### PR DESCRIPTION
When configuring for avr8 processors (--enable-avr8) linker fails with undefined reference to `table_avr8'. Fixed by adding TABLE_OBJS variable in configure script.

