### PR TITLE
Handle string containing comma in macro parameter

### DIFF
--- a/common/macros.c
+++ b/common/macros.c
@@ -646,7 +646,7 @@ char *macros_expand_params(struct _asm_context *asm_context, char *define, int p
       print_error("Macro expects ')'", asm_context);
       return NULL;
     }
-    if (ch == ',')
+    if (ch == ',' && !in_string)
     {
       params[ptr++] = 0;
       params_ptr[++count] = ptr;


### PR DESCRIPTION
Commas in strings in macro parameters would have higher precedence than the strings themselves, so that a single string containing a comma would be interpreted as two parameters, for example:

    .macro str(s)
    .ascii s
    .endm
    str(",")

This should expand to `.ascii ","`, but was instead erroring due to a mismatch in the number of parameters.