### PR TITLE
Skip whitespace after parenthesis/comma in macro

### DIFF
--- a/common/macros.c
+++ b/common/macros.c
@@ -639,6 +639,8 @@ char *macros_expand_params(struct _asm_context *asm_context, char *define, int p
   {
     ch = tokens_get_char(asm_context);
     if (ch == '\r') continue;
+    // skip whitespace immediately after opening parenthesis or a comma
+    if ((ch == ' ' || ch == '\t') && (ptr == 0 || params[ptr-1] == 0)) continue;
     if (ch == '"') { in_string = in_string ^ 1; }
     if (ch == ')' && in_string == 0) break;
     if (ch == '\n' || ch == EOF)


### PR DESCRIPTION
Currently, when calling a macro, any whitespace is significant. For example:

    .macro foo(bar, baz)
    label_baz:
    .endm
    foo(a, b)

causes errors because the label expands as `label_ b:`. To avoid this surprise, we skip any whitespace immediately after the opening parenthesis, or any comma in the parameter list.