### PR TITLE
Indexed Indirect addressing mode fix

### DIFF
--- a/simulate/6502.c
+++ b/simulate/6502.c
@@ -93,7 +93,7 @@ static int calc_address(struct _simulate *simulate, int address, int mode)
       indirect = (lo + 256 * hi) & 0xFFFF;
       return (READ_RAM(indirect) + 256 * READ_RAM((indirect + 1) & 0xFFFF)) & 0xFFFF;
     case OP_X_INDIRECT8:
-      indirect = ((READ_RAM(lo) + REG_X) & 0xFF) + 256 * READ_RAM((lo + 1) & 0xFF);
+      indirect = ((READ_RAM(lo + REG_X)) & 0xFF) + 256 * READ_RAM((lo + 1) & 0xFF);
       return (indirect) & 0xFFFF;
     case OP_INDIRECT8_Y:
       indirect = READ_RAM(lo) + 256 * READ_RAM((lo + 1) & 0xFF);


### PR DESCRIPTION
Indexing indirect addressing mode is weird and least used addressing mode in 6502 but sometimes it is life saver. In simulator indexing indirect address calculation is wrong. This PR should fix it