### PR TITLE
implemented case tolerant flag decoding for CPSID and CPSIE instructions

### DIFF
--- a/asm/thumb.c
+++ b/asm/thumb.c
@@ -218,11 +218,11 @@ int parse_cps(struct _asm_context *asm_context, int disable)
 
   while(token[n] != 0)
   {
-    if (token[n] == 'i')
+    if (token[n] == 'i' || token[n] == 'I' )
     {
       value |= 2;
     }
-    else if (token[n] == 'f')
+    else if ( token[n] == 'f' || token[n] == 'F' )
     {
       value |= 1;
     }

--- a/common/tokens.c
+++ b/common/tokens.c
@@ -339,6 +339,8 @@ int tokens_get(struct _asm_context *asm_context, char *token, int len)
           if (ch == 'n') { ch = '\n'; }
           else if (ch == 'r') { ch = '\r'; }
           else if (ch == 't') { ch = '\t'; }
+          else if (ch == '\"') { ch = '\"'; }
+          else if (ch == '\'') { ch = '\''; }
           else { tokens_unget_char(asm_context, ch); ch = '\\'; }
         }
 


### PR DESCRIPTION
Since everything else is case tolerant there is no reason the flags shouldn't be.