### PR TITLE
configure script: regexp operator no longer needed

### DIFF
--- a/configure
+++ b/configure
@@ -81,7 +81,7 @@ DFLAGS_ALL=`echo ${DFLAGS_ALL} | sed 's/^ *//'`
 
 for file in asm/*.c
 do
-  if [[ ! ${file} =~ "template" ]]
+  if [[ ! ${file} == *"template"* ]]
   then
     file=${file##*/}
     ASM_OBJS_ALL="${ASM_OBJS_ALL} ${file%.c}.o"
@@ -90,7 +90,7 @@ done
 
 for file in disasm/*.c
 do
-  if [[ ! ${file} =~ "template" ]]
+  if [[ ! ${file} == *"template"* ]]
   then
     file=${file##*/}
     DISASM_OBJS_ALL="${DISASM_OBJS_ALL} ${file%.c}.o"
@@ -99,7 +99,7 @@ done
 
 for file in table/*.c
 do
-  if [[ ! ${file} =~ "template" ]]
+  if [[ ! ${file} == *"template"* ]]
   then
     file=${file##*/}
     TABLE_OBJS_ALL="${TABLE_OBJS_ALL} ${file%.c}.o"
@@ -108,7 +108,7 @@ done
 
 for file in simulate/*.c
 do
-  if [[ ! ${file} =~ "template" ]]
+  if [[ ! ${file} == *"template"* ]]
   then
     file=${file##*/}
     SIM_OBJS_ALL="${SIM_OBJS_ALL} ${file%.c}.o"


### PR DESCRIPTION
Some versions of bash evidently lack support for the regexp operator
(=~). I found this to be the case with a version of MSYS. The configure
script uses a regular expression to exclude file names containing
"template" from being compiled. I've replaced with a simple substring
matching expression instead.