### PR TITLE
configure script: no longer uses regex operator

### DIFF
--- a/configure
+++ b/configure
@@ -81,7 +81,7 @@ DFLAGS_ALL=`echo ${DFLAGS_ALL} | sed 's/^ *//'`
 
 for file in asm/*.c
 do
-  if [[ ! ${file} == *"template"* ]]
+  if [[ ! ${file} == *"template.c" ]]
   then
     file=${file##*/}
     ASM_OBJS_ALL="${ASM_OBJS_ALL} ${file%.c}.o"
@@ -90,7 +90,7 @@ done
 
 for file in disasm/*.c
 do
-  if [[ ! ${file} == *"template"* ]]
+  if [[ ! ${file} == *"template.c" ]]
   then
     file=${file##*/}
     DISASM_OBJS_ALL="${DISASM_OBJS_ALL} ${file%.c}.o"
@@ -99,7 +99,7 @@ done
 
 for file in table/*.c
 do
-  if [[ ! ${file} == *"template"* ]]
+  if [[ ! ${file} == *"template.c" ]]
   then
     file=${file##*/}
     TABLE_OBJS_ALL="${TABLE_OBJS_ALL} ${file%.c}.o"
@@ -108,7 +108,7 @@ done
 
 for file in simulate/*.c
 do
-  if [[ ! ${file} == *"template"* ]]
+  if [[ ! ${file} == *"template.c" ]]
   then
     file=${file##*/}
     SIM_OBJS_ALL="${SIM_OBJS_ALL} ${file%.c}.o"

--- a/configure
+++ b/configure
@@ -81,7 +81,7 @@ DFLAGS_ALL=`echo ${DFLAGS_ALL} | sed 's/^ *//'`
 
 for file in asm/*.c
 do
-  if [[ ! ${file} =~ "template" ]]
+  if [[ ! ${file} == *"template"* ]]
   then
     file=${file##*/}
     ASM_OBJS_ALL="${ASM_OBJS_ALL} ${file%.c}.o"
@@ -90,7 +90,7 @@ done
 
 for file in disasm/*.c
 do
-  if [[ ! ${file} =~ "template" ]]
+  if [[ ! ${file} == *"template"* ]]
   then
     file=${file##*/}
     DISASM_OBJS_ALL="${DISASM_OBJS_ALL} ${file%.c}.o"
@@ -99,7 +99,7 @@ done
 
 for file in table/*.c
 do
-  if [[ ! ${file} =~ "template" ]]
+  if [[ ! ${file} == *"template"* ]]
   then
     file=${file##*/}
     TABLE_OBJS_ALL="${TABLE_OBJS_ALL} ${file%.c}.o"
@@ -108,7 +108,7 @@ done
 
 for file in simulate/*.c
 do
-  if [[ ! ${file} =~ "template" ]]
+  if [[ ! ${file} == *"template"* ]]
   then
     file=${file##*/}
     SIM_OBJS_ALL="${SIM_OBJS_ALL} ${file%.c}.o"

--- a/configure
+++ b/configure
@@ -81,7 +81,7 @@ DFLAGS_ALL=`echo ${DFLAGS_ALL} | sed 's/^ *//'`
 
 for file in asm/*.c
 do
-  if [[ ! ${file} == *"template.c" ]]
+  if [[ ! $(basename ${file})  == "template.c" ]]
   then
     file=${file##*/}
     ASM_OBJS_ALL="${ASM_OBJS_ALL} ${file%.c}.o"
@@ -90,7 +90,7 @@ done
 
 for file in disasm/*.c
 do
-  if [[ ! ${file} == *"template.c" ]]
+  if [[ ! $(basename ${file}) == "template.c" ]]
   then
     file=${file##*/}
     DISASM_OBJS_ALL="${DISASM_OBJS_ALL} ${file%.c}.o"
@@ -99,7 +99,7 @@ done
 
 for file in table/*.c
 do
-  if [[ ! ${file} == *"template.c" ]]
+  if [[ ! $(basename ${file}) == "template.c" ]]
   then
     file=${file##*/}
     TABLE_OBJS_ALL="${TABLE_OBJS_ALL} ${file%.c}.o"
@@ -108,7 +108,7 @@ done
 
 for file in simulate/*.c
 do
-  if [[ ! ${file} == *"template.c" ]]
+  if [[ ! $(basename ${file}) == "template.c" ]]
   then
     file=${file##*/}
     SIM_OBJS_ALL="${SIM_OBJS_ALL} ${file%.c}.o"


### PR DESCRIPTION
Some versions of bash seem to lack support for the regex (=~) operator and
always return false rather than erroring out. This causes the template files
to be erroneously included in the dependencies. Using a string comparison
with wildcards should accomplish the same thing on a wider variety of bash
versions: detect 'template' in the filename and exclude it.