### PR TITLE
Check same page jumps on second pass only (8048)

### DIFF
--- a/asm/8048.c
+++ b/asm/8048.c
@@ -194,16 +194,18 @@ static int process_op(
       else
     if (type == OP_PADDR)
     {
-      int address = operand->value;
-
-      if ((address & 0xff00) != (asm_context->address & 0xff00))
+      if (asm_context->pass == 2)
       {
-        print_error("Address isn't on same page", asm_context);
-        return -1;
+        int address = operand->value;
+
+        if ((address & 0xff00) != (asm_context->address & 0xff00))
+        {
+          print_error("Address isn't on same page", asm_context);
+          return -1;
+        }
+
+        data[1] = operand->value & 0xff;
       }
-
-      data[1] = operand->value & 0xff;
-
       return 2;
     }
   }

--- a/asm/8048.c
+++ b/asm/8048.c
@@ -203,9 +203,8 @@ static int process_op(
           print_error("Address isn't on same page", asm_context);
           return -1;
         }
-
-        data[1] = operand->value & 0xff;
       }
+      data[1] = operand->value & 0xff;
       return 2;
     }
   }


### PR DESCRIPTION
This PR moves verification of target in-page address to second pass only.
Previously, it failed on onresolved jumps in addresses over 256 bytes.
