### PR TITLE
Handle tabs on equ statement lines

### DIFF
--- a/common/assembler.c
+++ b/common/assembler.c
@@ -402,6 +402,7 @@ int assemble(struct _asm_context *asm_context)
           {
             ch = tokens_get_char(asm_context);
             if (ch == EOF || ch == '\n') break;
+            if (ch == '\t') { ch = ' '; }
             if (ch == '*' && ptr > 0 && token2[ptr - 1] == '/')
             {
               macros_strip_comment(asm_context);


### PR DESCRIPTION
This fixes another issue I found when compiling old code with tab spacing. 
The code had `equ` statements followed by comments:

```asm
    FOO equ 0<tab><tab>; Comments
```

Later, the `FOO` macro was not accepted as a number in `.if` directives, since the tabs were kept in the macro and are not considered numeric.
Not sure this fix is the best way to handle it, but it does solve the problem.