### PR TITLE
Update z80.cpp for hex instead of decimal disassembly print items

### DIFF
--- a/disasm/z80.cpp
+++ b/disasm/z80.cpp
@@ -9,10 +9,6 @@
  *
  */
 
-// define for hex output instead of decimal for:
-// IN/OUT/JR/LD_IX/LD_IY/LD_HL/LD_REG/Immediate AND/OR/XOR/CP/ADC/ADD/SBC/SUB
-#define HEX_OUTPUT
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -118,11 +114,7 @@ int disasm_z80(
         }
         case OP_A_NUMBER8:
         {
-#ifdef HEX_OUTPUT
           snprintf(instruction, length, "%s a,0x%02x", instr, READ_RAM(address + 1));
-#else
-          snprintf(instruction, length, "%s a,%d", instr, READ_RAM(address + 1));
-#endif
           return 2;
         }
         case OP_HL_REG16_1:
@@ -142,11 +134,7 @@ int disasm_z80(
         }
         case OP_NUMBER8:
         {
-#ifdef HEX_OUTPUT
           snprintf(instruction, length, "%s 0x%02x", instr, READ_RAM(address + 1));
-#else
-          snprintf(instruction, length, "%s %d", instr, READ_RAM(address + 1));
-#endif
           return 2;
         }
         case OP_ADDRESS:
@@ -189,32 +177,20 @@ int disasm_z80(
         }
         case OP_A_INDEX_N:
         {
-#ifdef HEX_OUTPUT
           snprintf(instruction, length, "%s a,(0x%02x)", instr, READ_RAM(address + 1));
-#else
-          snprintf(instruction, length, "%s a,(%d)", instr, READ_RAM(address + 1));
-#endif
           return 2;
         }
         case OP_OFFSET8:
         {
           i = (int8_t)READ_RAM(address + 1);
-#ifdef HEX_OUTPUT
           snprintf(instruction, length, "%s 0x%04x  (%d)", instr, (address + 2) + i, i);
-#else
-          snprintf(instruction, length, "%s %d  (%d)", instr, (address + 2) + i, i);
-#endif
           return 2;
         }
         case OP_JR_COND_ADDRESS:
         {
           r = (opcode >> 3) & 0x3;
           i = (int8_t)READ_RAM(address + 1);
-#ifdef HEX_OUTPUT
           snprintf(instruction, length, "%s %s,0x%04x  (%d)", instr, cond[r], (address + 2) + i, i);
-#else
-          snprintf(instruction, length, "%s %s,%d  (%d)", instr, cond[r], (address + 2) + i, i);
-#endif
           return 2;
         }
         case OP_REG8_REG8:
@@ -227,11 +203,7 @@ int disasm_z80(
         case OP_REG8_NUMBER8:
         {
           r = (opcode >> 3) & 0x7;
-#ifdef HEX_OUTPUT
           snprintf(instruction, length, "%s %s,0x%02x", instr, reg8[r],READ_RAM(address + 1));
-#else
-          snprintf(instruction, length, "%s %s,%d", instr, reg8[r],READ_RAM(address + 1));
-#endif
           return 2;
         }
         case OP_REG8_INDEX_HL:
@@ -248,11 +220,7 @@ int disasm_z80(
         }
         case OP_INDEX_HL_NUMBER8:
         {
-#ifdef HEX_OUTPUT
           snprintf(instruction, length, "%s (hl),0x%02x", instr, READ_RAM(address + 1));
-#else
-          snprintf(instruction, length, "%s (hl),%d", instr, READ_RAM(address + 1));
-#endif
           return 2;
         }
         case OP_A_INDEX_BC:
@@ -308,11 +276,7 @@ int disasm_z80(
         }
         case OP_INDEX_ADDRESS8_A:
         {
-#ifdef HEX_OUTPUT
           snprintf(instruction, length, "%s (0x%02x),a", instr, READ_RAM(address + 1));
-#else
-          snprintf(instruction, length, "%s (%d),a", instr, READ_RAM(address + 1));
-#endif
           return 2;
         }
         case OP_REG16P:
@@ -560,11 +524,7 @@ int disasm_z80(
           r = (opcode16 >> 13) & 0x1;
           offset = READ_RAM(address + 2);
           get_disp(disp, sizeof(disp), r, offset);
-#ifdef HEX_OUTPUT
           snprintf(instruction, length, "%s %s,0x%02x", instr, disp, READ_RAM(address + 3));
-#else
-          snprintf(instruction, length, "%s %s,%d", instr, disp, READ_RAM(address + 3));
-#endif
           return 4;
         }
         case OP_IR_A:

--- a/disasm/z80.cpp
+++ b/disasm/z80.cpp
@@ -9,6 +9,10 @@
  *
  */
 
+// define for hex output instead of decimal for:
+// IN/OUT/JR/LD_IX/LD_IY/LD_HL/LD_REG/Immediate AND/OR/XOR/CP/ADC/ADD/SBC/SUB
+#define HEX_OUTPUT
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -114,7 +118,11 @@ int disasm_z80(
         }
         case OP_A_NUMBER8:
         {
+#ifdef HEX_OUTPUT
+          snprintf(instruction, length, "%s a,0x%02x", instr, READ_RAM(address + 1));
+#else
           snprintf(instruction, length, "%s a,%d", instr, READ_RAM(address + 1));
+#endif
           return 2;
         }
         case OP_HL_REG16_1:
@@ -134,7 +142,11 @@ int disasm_z80(
         }
         case OP_NUMBER8:
         {
+#ifdef HEX_OUTPUT
+          snprintf(instruction, length, "%s 0x%02x", instr, READ_RAM(address + 1));
+#else
           snprintf(instruction, length, "%s %d", instr, READ_RAM(address + 1));
+#endif
           return 2;
         }
         case OP_ADDRESS:
@@ -177,20 +189,32 @@ int disasm_z80(
         }
         case OP_A_INDEX_N:
         {
+#ifdef HEX_OUTPUT
+          snprintf(instruction, length, "%s a,(0x%02x)", instr, READ_RAM(address + 1));
+#else
           snprintf(instruction, length, "%s a,(%d)", instr, READ_RAM(address + 1));
+#endif
           return 2;
         }
         case OP_OFFSET8:
         {
           i = (int8_t)READ_RAM(address + 1);
+#ifdef HEX_OUTPUT
+          snprintf(instruction, length, "%s 0x%04x  (%d)", instr, (address + 2) + i, i);
+#else
           snprintf(instruction, length, "%s %d  (%d)", instr, (address + 2) + i, i);
+#endif
           return 2;
         }
         case OP_JR_COND_ADDRESS:
         {
           r = (opcode >> 3) & 0x3;
           i = (int8_t)READ_RAM(address + 1);
+#ifdef HEX_OUTPUT
+          snprintf(instruction, length, "%s %s,0x%04x  (%d)", instr, cond[r], (address + 2) + i, i);
+#else
           snprintf(instruction, length, "%s %s,%d  (%d)", instr, cond[r], (address + 2) + i, i);
+#endif
           return 2;
         }
         case OP_REG8_REG8:
@@ -203,7 +227,11 @@ int disasm_z80(
         case OP_REG8_NUMBER8:
         {
           r = (opcode >> 3) & 0x7;
+#ifdef HEX_OUTPUT
+          snprintf(instruction, length, "%s %s,0x%02x", instr, reg8[r],READ_RAM(address + 1));
+#else
           snprintf(instruction, length, "%s %s,%d", instr, reg8[r],READ_RAM(address + 1));
+#endif
           return 2;
         }
         case OP_REG8_INDEX_HL:
@@ -220,7 +248,11 @@ int disasm_z80(
         }
         case OP_INDEX_HL_NUMBER8:
         {
+#ifdef HEX_OUTPUT
+          snprintf(instruction, length, "%s (hl),0x%02x", instr, READ_RAM(address + 1));
+#else
           snprintf(instruction, length, "%s (hl),%d", instr, READ_RAM(address + 1));
+#endif
           return 2;
         }
         case OP_A_INDEX_BC:
@@ -276,7 +308,11 @@ int disasm_z80(
         }
         case OP_INDEX_ADDRESS8_A:
         {
+#ifdef HEX_OUTPUT
+          snprintf(instruction, length, "%s (0x%02x),a", instr, READ_RAM(address + 1));
+#else
           snprintf(instruction, length, "%s (%d),a", instr, READ_RAM(address + 1));
+#endif
           return 2;
         }
         case OP_REG16P:
@@ -524,7 +560,11 @@ int disasm_z80(
           r = (opcode16 >> 13) & 0x1;
           offset = READ_RAM(address + 2);
           get_disp(disp, sizeof(disp), r, offset);
+#ifdef HEX_OUTPUT
+          snprintf(instruction, length, "%s %s,0x%02x", instr, disp, READ_RAM(address + 3));
+#else
           snprintf(instruction, length, "%s %s,%d", instr, disp, READ_RAM(address + 3));
+#endif
           return 4;
         }
         case OP_IR_A:


### PR DESCRIPTION
For more usable for developers Z80 disassembler output, change many of the decimal numbers to hex numbers. The #define HEX_OUTPUT can be undefined to revert back to the original output with a re-compile of the code.

For example:
'
  out (0),a      =>   out (0x00),a
  out (64),a     =>   out (0x40),a
  out (240),a    =>   out (0xf0),a
  out (176),a    =>   out (0xb0),a

  in a,(0)       =>   in a,(0x00)
  in a,(127)     =>   in a,(0x7f)
  in a,(255)     =>   in a,(0xff)
  in a,(176)     =>   in a,(0xb0)

  djnz 141  (8)  =>   djnz 0x008d  (8)
  jr c,141  (6)  =>   jr c,0x008d  (6)
  jr nc,141  (4) =>   jr nc,0x008d  (4)
  jr z,141  (2)  =>   jr z,0x008d  (2)
  jr nz,141  (0) =>   jr nz,0x008d  (0)
  jr 394  (127)  =>   jr 0x018a  (127)
  jr 141  (-128) =>   jr 0x008d  (-128)

  cp 255         =>   cp 0xff
  xor 255        =>   xor 0xff
  or 255         =>   or 0xff
  and 255        =>   and 0xff
  sbc a,255      =>   sbc a,0xff
  sub 255        =>   sub 0xff
  adc a,255      =>   adc a,0xff
  add a,255      =>   add a,0xff

  ld (ix+5),6    =>   ld (ix+5),0x06
  ld (iy),238    =>   ld (iy),0xee
  ld (hl),254    =>   ld (hl),0xfe

  ld a,255       =>   ld a,0xff
  ld b,1         =>   ld b,0x01
  ld c,2         =>   ld c,0x02
  ld d,4         =>   ld d,0x04
  ld e,8         =>   ld e,0x08
  ld h,16        =>   ld h,0x10
  ld l,18        =>   ld l,0x12
'