### PR TITLE
Add an emulated serial port which can be attached to files on the host

### DIFF
--- a/docs/simulating.md
+++ b/docs/simulating.md
@@ -57,3 +57,12 @@ exit the simulator if written so:
 So now if the running program.hex does a mov.b #5, 0x0000 then the
 simulator exit with a return code of 5.
 
+To emulate a serial port, a set of 3 options is used as a group:
+	-serial_addr <address> is used to specify a memory mapped address
+	-serial_out <outputfile> is used to denote that writing a byte to the
+		<address> specified by -serial_addr will write that byte
+		to the <outputfile>
+	-serial_in <inputfile> is used to denote that reading a byte from the
+		<address> specified by -serial_addr will read a byte
+		from the <inputfile>
+This is currently implemented for AVR8 and MSP430

--- a/simulate/Simulate.h
+++ b/simulate/Simulate.h
@@ -28,6 +28,9 @@ public:
     usec              (1000000),
     break_point       (0xffffffff),
     break_io          (0),
+    serial_addr       (0),
+    serial_in         (NULL),
+    serial_out        (NULL),
     step_mode         (false),
     show              (true),
     auto_run          (true)
@@ -62,6 +65,9 @@ public:
   void set_break_point(int value) { break_point = value; }
   void set_delay(useconds_t value) { usec = value; }
   void set_break_io(int value) { break_io = value; }
+  void set_serial_addr(int value) { serial_addr = value; }
+  void set_serial_in(FILE *value) { serial_in = value; }
+  void set_serial_out(FILE *value) { serial_out = value; }
 
   void remove_break_point() { break_point = -1; }
   bool is_break_point_set() { return break_point == -1; }
@@ -100,6 +106,9 @@ protected:
   useconds_t usec;
   int break_point;
   int break_io;
+  int serial_addr;
+  FILE *serial_in;
+  FILE *serial_out;
   bool step_mode : 1;
   bool show : 1;
   bool auto_run : 1;

--- a/simulate/avr8.cpp
+++ b/simulate/avr8.cpp
@@ -72,8 +72,13 @@
 #define READ_FLASH(n) memory->read8(n)
 #define WRITE_FLASH(n,data) memory->write8(n, data)
 
-#define READ_RAM(a) ram[a & RAM_MASK];
-#define WRITE_RAM(a,v) ram[a & RAM_MASK] = v;
+#define READ_RAM(a) ((a == serial_addr) ? fgetc(serial_in) : ram[a & RAM_MASK])
+#define WRITE_RAM(a,v) \
+  if (a == serial_addr) \
+  { \
+    fputc(v, serial_out); \
+  } else \
+    ram[a & RAM_MASK] = v;
 
 SimulateAvr8::SimulateAvr8(Memory *memory) : Simulate(memory)
 {

--- a/simulate/msp430.cpp
+++ b/simulate/msp430.cpp
@@ -19,13 +19,17 @@
 #include "simulate/msp430.h"
 
 #define SHOW_STACK sp, memory->read8(sp + 1), memory->read8(sp)
-#define READ_RAM(a) memory->read8(a)
+#define READ_RAM(a) ((a == serial_addr) ? fgetc(serial_in) : memory->read8(a))
 #define WRITE_RAM(a,b) \
   if (a == break_io) \
   { \
     exit(b); \
   } \
-  memory->write8(a, b);
+  if (a == serial_addr) \
+  { \
+    fputc(b, serial_out); \
+  } else \
+    memory->write8(a, b);
 
 const char *SimulateMsp430::flags[] =
 {


### PR DESCRIPTION
During simulation it is sometimes convenient to have a fake serial port attached to files on the running host which
can be accessed via a memory mapped address. For example, I use this as a means of regression testing of the
REPL of a [Forth dialect called romforth](https://github.com/romforth/romforth) that I've been working on.

There are other emulators that implement something like this. For example,
[ucsim](https://github.com/danieldrotos/ucsim), enables this by using a command line -I option such that on the
ucsim 8051 simulator you can invoke it like this:

        ucsim_51 -I in=test.in,out=test.out,if=xram'[0xffff]'

to indicate that any bytes written to address 0xffff will be written to the file `test.out` and any bytes that are read
from that address will result in a read from `test.in`. (I've glossed over the details since in reality it uses in-band
signalling so the details are more complicated than what I've tried to summarize here)

Another such emulator that has this functionality is [mspdebug](https://github.com/dlbeer/mspdebug) which supports
this feature by using the "simio console" commands. For example, you could add a serial port to the simulation
(at default address 0xff) by running the following commands after starting up `mspdebug -n sim`
        simio add console serial
        simio config serial output test.out

Unlike ucsim, mspdebug does not have support for an input file, so I needed to add that support in
[my fork](https://github.com/romforth/mspdebug) of mspdebug which allows reading from a file via the serial port
input by using the following additional command:
        simio config serial input test.in

It would be nice if naken_util also provided a facility to emulate serial ports using either of these emulators as a
template. It might be easy to extend the existing set of CLI arguments to also add support for a serial port attached to
files by adding three more flags called -serial-addr, -serial_in and -serial_out which would allow serial port emulation
from files by running it like this:
        naken_util -run \
                -serial_in test.in \
                -serial_out test.out \
                -serial-addr 0xffff

In [my fork](https://github.com/romforth/naken_asm) of naken_asm I have added the support for this feature
but it is currently only implemented for the AVR8 port and the MSP430 ports. The MSP430 port was used as
a proof of concept and the AVR8 port is the one for which I plan to use naken_util in my
[romforth project](https://github.com/romforth/romforth)).

The way it is currently coded, any write to the serial_addr address now results in the character getting printed
to the serial_out file. Similarly for a read from the serial_addr address, a character from the serial_in file will be
read in. Since I do need this feature in my own project where I plan to use naken_util, I will continue to use my
[own fork](https://github.com/romforth/naken_asm) of this code. So feel free to use this change as is or modify
it as appropriate for your purposes.

Thanks for creating naken_asm and naken_util - I look forward to using it :)
Charles E. Suresh
(romforth on Github)
